### PR TITLE
quad adc update

### DIFF
--- a/xps_lib/XPS_ROACH_base/pcores/quadc_interface_v1_00_a/data/quadc_interface_v2_1_0.mpd
+++ b/xps_lib/XPS_ROACH_base/pcores/quadc_interface_v1_00_a/data/quadc_interface_v2_1_0.mpd
@@ -49,6 +49,8 @@ PORT adc2_clk = "",         DIR = O
 PORT adc3_clk = "",         DIR = O
 
 PORT adc0_clk90 = "",       DIR = O
+PORT adc0_clk180 = "",      DIR = O
+PORT adc0_clk270 = "",      DIR = O
 
 PORT adc0_data = "",        DIR = O, VEC = [7:0]
 PORT adc1_data = "",        DIR = O, VEC = [7:0]

--- a/xps_lib/XPS_ROACH_base/pcores/quadc_interface_v1_00_a/hdl/verilog/quadc_interface.v
+++ b/xps_lib/XPS_ROACH_base/pcores/quadc_interface_v1_00_a/hdl/verilog/quadc_interface.v
@@ -30,6 +30,8 @@ module quadc_interface (
                 adc3_clk,
 
                 adc0_clk90,
+                adc0_clk180,
+                adc0_clk270,
 
                 adc0_data,
                 adc1_data,
@@ -74,6 +76,8 @@ module quadc_interface (
     output          adc3_clk;
 
     output          adc0_clk90;
+    output          adc0_clk180;
+    output          adc0_clk270;
 
     output [7:0]    adc0_data;
     output [7:0]    adc1_data;
@@ -98,10 +102,14 @@ module quadc_interface (
 
     wire            adc0_clk_buf;
     wire            adc0_clk_90_buf;
+    wire            adc0_clk_180_buf;
+    wire            adc0_clk_270_buf;
     wire            adc0_clk_2x_buf;
 
     wire            adc0_clk;
     wire            adc0_clk_90;
+    wire            adc0_clk_180;
+    wire            adc0_clk_270;
     wire            adc0_clk_2x;
 
     wire            dcm_adc0_locked;
@@ -231,6 +239,16 @@ module quadc_interface (
             .O(adc0_clk_90)
         );
 
+    BUFG BUFG_ADC0CLK180 (
+            .I(adc0_clk_180_buf),
+            .O(adc0_clk_180)
+        );
+    
+    BUFG BUFG_ADC0CLK270 (
+            .I(adc0_clk_270_buf),
+            .O(adc0_clk_270)
+        );
+
     BUFG BUFG_ADC0CLK2X (
             .I(adc0_clk_2x_buf),
             .O(adc0_clk_2x)
@@ -261,8 +279,8 @@ generate
                 .CLKIN   (adc0_clk_in),                         // Clock input (from IBUFG, BUFG or DCM)
                 .CLK0    (adc0_clk_buf),                        // 0 degree DCM CLK output
                 .CLK90   (adc0_clk_90_buf),                     // 90 degree DCM CLK output
-                .CLK180  (),                                    // 180 degree DCM CLK output
-                .CLK270  (),                                    // 270 degree DCM CLK output
+                .CLK180  (adc0_clk_180_buf),                    // 180 degree DCM CLK output
+                .CLK270  (adc0_clk_270_buf),                    // 270 degree DCM CLK output
                 .CLK2X   (adc0_clk_2x_buf),                     // 2X DCM CLK output
                 .CLK2X180(),                                    // 2X, 180 degree DCM CLK out
                 .CLKDV   (),                                    // Divided DCM CLK out (CLKDV_DIVIDE)
@@ -296,8 +314,8 @@ generate
                 .CLKIN   (adc0_clk_in),                         // Clock input (from IBUFG, BUFG or DCM)
                 .CLK0    (adc0_clk_buf),                        // 0 degree DCM CLK output
                 .CLK90   (adc0_clk_90_buf),                     // 90 degree DCM CLK output
-                .CLK180  (),                                    // 180 degree DCM CLK output
-                .CLK270  (),                                    // 270 degree DCM CLK output
+		.CLK180  (adc0_clk_180_buf),                    // 180 degree DCM CLK output
+                .CLK270  (adc0_clk_270_buf),                    // 270 degree DCM CLK output
                 .CLK2X   (adc0_clk_2x_buf),                     // 2X DCM CLK output
                 .CLK2X180(),                                    // 2X, 180 degree DCM CLK out
                 .CLKDV   (),                                    // Divided DCM CLK out (CLKDV_DIVIDE)
@@ -333,6 +351,8 @@ endgenerate
     );
 
     assign  adc0_clk90 = adc0_clk_90;
+    assign  adc0_clk180 = adc0_clk_180;
+    assign  adc0_clk270 = adc0_clk_270;
     assign  valid      = fifo_valid;
 
     always @ (negedge adc0_clk) begin

--- a/xps_library/@xps_quadc/xps_quadc.m
+++ b/xps_library/@xps_quadc/xps_quadc.m
@@ -85,6 +85,8 @@ misc_ports.adc1_clk  =  {1 'out' ['quadc0_', s.adc_brd, '_adc1_clk']};
 misc_ports.adc2_clk  =  {1 'out' ['quadc0_', s.adc_brd, '_adc2_clk']};
 misc_ports.adc3_clk  =  {1 'out' ['quadc0_', s.adc_brd, '_adc3_clk']};
 misc_ports.adc0_clk90 = {1 'out' [s.adc_str, '_clk90']};
+misc_ports.adc0_clk180 = {1 'out' [s.adc_str, '_clk180']};
+misc_ports.adc0_clk270 = {1 'out' [s.adc_str, '_clk270']};
 
 b = set(b,'misc_ports',misc_ports);
 


### PR DESCRIPTION
Now outputs clk180 and clk270 signals from DCM for use by other
yellow blocks (e.g. qdr_controller).
