### PR TITLE
dec_fir_init.m more parameter checking

### DIFF
--- a/casper_library/dec_fir_init.m
+++ b/casper_library/dec_fir_init.m
@@ -91,7 +91,7 @@ num_fir_col = length(coeff) / n_inputs;
 coeff_sym = 0;
 fir_col_type = 'fir_col';
 
-if mod(length(coeff),2) == 0, 
+if mod(length(coeff),2) == 0 && mod(num_fir_col, 2)==0 
   if coeff_round(1:length(coeff)/2) == coeff_round(length(coeff):-1:length(coeff)/2+1),
     num_fir_col = num_fir_col / 2;
     fir_col_type = 'fir_dbl_col';


### PR DESCRIPTION
An attempt to fix the dec_fir problem in an easy way. We could do better... but this solution is relatively clean and solves our problem for now. 

---

When the given coefficients vector is symmetric, and length(coeff)/n_inputs is an odd integer, the block won't draw properly.

The problem was due to insufficient parameter checking -- we only made sure num_fir_col is an integer ([line 84~90 in dec_fir_init.m](https://github.com/casper-astro/mlib_devel/blob/2f22893477e5c20c327d20a4d8347738c3f0c00e/casper_library/dec_fir_init.m#L84)) before we do the following ([line 90~100](https://github.com/casper-astro/mlib_devel/blob/2f22893477e5c20c327d20a4d8347738c3f0c00e/casper_library/dec_fir_init.m#L90)):

``` matlab
num_fir_col = length(coeff) / n_inputs;
coeff_sym = 0;
fir_col_type = 'fir_col';

if mod(length(coeff),2) == 0, 
  if coeff_round(1:length(coeff)/2) == coeff_round(length(coeff):-1:length(coeff)/2+1),
    num_fir_col = num_fir_col / 2;
    fir_col_type = 'fir_dbl_col';
    coeff_sym = 1;
  end
end
```

Note in the case that coefficient vector is symmetric (hence must have even length), we compute new value for num_fir_col (in [line 96](https://github.com/casper-astro/mlib_devel/blob/2f22893477e5c20c327d20a4d8347738c3f0c00e/casper_library/dec_fir_init.m#L96)) as

``` matlab
    num_fir_col = num_fir_col / 2;
```

Recall that num_fir_col was first computed as

``` matlab
num_fir_col = length(coeff) / n_inputs;
```

in [line 90](https://github.com/casper-astro/mlib_devel/blob/2f22893477e5c20c327d20a4d8347738c3f0c00e/casper_library/dec_fir_init.m#L90). We can see that there's actually no guarantee that length(coeff) / n_inputs would be even or odd, hence the final value we got for num_fir_col may not be an integer, which would be a problem later on. One obvious example is in [line 233](https://github.com/casper-astro/mlib_devel/blob/2f22893477e5c20c327d20a4d8347738c3f0c00e/casper_library/dec_fir_init.m#L233):

``` matlab
if coeff_sym,
    [ine 221~230 omitted]

    for j=1:n_inputs,
        blk_name = [fir_col_type,num2str(num_fir_col)];
        add_line(blk,[blk_name,'/',num2str(j*2-1)],[blk_name,'/',num2str(2*n_inputs+j*2-1)]);
        add_line(blk,[blk_name,'/',num2str(j*2)],[blk_name,'/',num2str(2*n_inputs+j*2)]);
    end
end
```

We would often see error message saying something like "block 'fir_dbl_col0.5' not found" and we can see why.

This commit fixes this problem by adding parameter checking to make sure num_fir_col will always be an integer -- there would be times that we don't do coefficient folding when we actually can (hence use more resource than strictly needed), but I think it at least draws properly now.

---

A more elaborated (but still incomplete) fix is available [here](https://github.com/cs150bf/mlib_devel/blob/9132e82f69e7576b04b28feaaaf4ed7a3e56ef7f/casper_library/dec_fir_init.m).

This version takes care of the case where the coefficeint vector is symmetric, and length(coeff) == n_inputs.
