### PR TITLE
Update MKID ADC MMCM and clock phase

### DIFF
--- a/xps_base/XPS_ROACH2_base/pcores/adc_mkid_interface_v1_00_a/hdl/vhdl/adc_mkid_interface.vhd
+++ b/xps_base/XPS_ROACH2_base/pcores/adc_mkid_interface_v1_00_a/hdl/vhdl/adc_mkid_interface.vhd
@@ -174,7 +174,7 @@ architecture Structural of adc_mkid_interface is
             BANDWIDTH          : string  := "OPTIMIZED"; -- Jitter programming ("HIGH","LOW","OPTIMIZED")
             CLKFBOUT_MULT_F    : integer := 8;           -- Multiply value for all CLKOUT (5.0-64.0). THIS IS THE MULTIPLIER
             CLKFBOUT_PHASE     : real    := 0.0;
-            CLKIN1_PERIOD      : real    := 5.0;
+            CLKIN1_PERIOD      : real    := 4.0;
             CLKOUT0_DIVIDE_F   : integer := 4;           -- Divide amount for CLKOUT0 (1.000-128.000).
             CLKOUT0_DUTY_CYCLE : real    := 0.5; 
             CLKOUT1_DUTY_CYCLE : real    := 0.5;
@@ -198,7 +198,7 @@ architecture Structural of adc_mkid_interface is
             CLKOUT6_DIVIDE     : integer := 1;
             CLKOUT4_CASCADE    : string  := "FALSE";
             CLOCK_HOLD         : string  := "FALSE";
-            DIVCLK_DIVIDE      : integer := 1;            -- Master division value (1-80)
+            DIVCLK_DIVIDE      : integer := 2;            -- Master division value (1-80)
             REF_JITTER1        : real    := 0.0;
             STARTUP_WAIT       : string  := "FALSE"
         );
@@ -259,7 +259,7 @@ begin
       port map (
         Q1 => data_rise_i(j),
         Q2 => data_fall_i(j),
-        C => clk,
+        C => clk90,
         CE => '1',
         D => data_i(j),
         R => '0',
@@ -287,7 +287,7 @@ begin
       port map (
         Q1 => data_rise_q(j),
         Q2 => data_fall_q(j),
-        C => clk,
+        C => clk90,
         CE => '1',
         D => data_q(j),
         R => '0',
@@ -440,10 +440,10 @@ begin
 		MMCM_adc : MMCM_BASE
     		generic map(
         		BANDWIDTH          => "OPTIMIZED", -- Jitter programming ("HIGH","LOW","OPTIMIZED")
-        		CLKFBOUT_MULT_F    => 5,           -- Multiply value for all CLKOUT (5.0-64.0). THIS IS THE MULTIPLIER
+        		CLKFBOUT_MULT_F    => 8,           -- Multiply value for all CLKOUT (5.0-64.0). THIS IS THE MULTIPLIER
         		CLKFBOUT_PHASE     => 0.0,
-        		CLKIN1_PERIOD      => 1.9536,
-        		CLKOUT0_DIVIDE_F   => 5,           -- Divide amount for CLKOUT0 (1.000-128.000).
+        		CLKIN1_PERIOD      => 4.0,
+        		CLKOUT0_DIVIDE_F   => 4,           -- Divide amount for CLKOUT0 (1.000-128.000).
         		CLKOUT0_DUTY_CYCLE => 0.5,
         		CLKOUT1_DUTY_CYCLE => 0.5,
         		CLKOUT2_DUTY_CYCLE => 0.5,
@@ -458,15 +458,15 @@ begin
         		CLKOUT4_PHASE      => 0.0,
         		CLKOUT5_PHASE      => 0.0,
         		CLKOUT6_PHASE      => 0.0,
-        		CLKOUT1_DIVIDE     => 5,            -- THIS IS THE DIVISOR
-        		CLKOUT2_DIVIDE     => 5,
-        		CLKOUT3_DIVIDE     => 5,
+        		CLKOUT1_DIVIDE     => 4,            -- THIS IS THE DIVISOR
+        		CLKOUT2_DIVIDE     => 4,
+        		CLKOUT3_DIVIDE     => 4,
         		CLKOUT4_DIVIDE     => 1,
         		CLKOUT5_DIVIDE     => 1,
         		CLKOUT6_DIVIDE     => 1,
         		CLKOUT4_CASCADE    => "FALSE",
         		CLOCK_HOLD         => "FALSE",
-        		DIVCLK_DIVIDE      => 1,            -- Master division value (1-80)
+        		DIVCLK_DIVIDE      => 2,            -- Master division value (1-80)
         		REF_JITTER1        => 0.0,
         		STARTUP_WAIT       => "FALSE")
     		port map(


### PR DESCRIPTION
This is an attempt to improve the MMCM clock parameters for clocking the ADC at >480 MHz.

I also set the IDDR clock to clk90 instead of the default clk. From the timing diagrams in the datasheet, the data transitions on the same edge as the DRDY signal. DRDY is the input to the MMCM and clk is in phase with DRDY. We actualy want to sample the data 90 degrees out of phase with DRDY, so I think the IDDR clock should be clk90.
I ran into some glitches using the default clk choice, and when I switched to clk90, they went away, hence this commit.