### PR TITLE
Remove JASPER's Ruby dependency :.(

### DIFF
--- a/jasper_library/cit2bin.rb
+++ b/jasper_library/cit2bin.rb
@@ -1,1 +1,0 @@
-sw/jam/util/cit2bin.rb

--- a/jasper_library/cit2csl.py
+++ b/jasper_library/cit2csl.py
@@ -1,0 +1,1 @@
+sw/jam/util/cit2csl.py

--- a/jasper_library/cit2mem.rb
+++ b/jasper_library/cit2mem.rb
@@ -1,1 +1,0 @@
-sw/jam/util/cit2mem.rb

--- a/jasper_library/sw/jam/Makefile
+++ b/jasper_library/sw/jam/Makefile
@@ -119,7 +119,7 @@ core_info.o: core_info.bin
 		$< $@
 
 core_info.bin: core_info.tab
-	ruby ./util/cit2bin.rb $< > $@
+	python ./util/cit2csl.py -b $< > $@
 
 symbols: $(EXEC)
 	mb-readelf -s $< | sort -rnk3 > $@

--- a/jasper_library/sw/jam/test/Makefile
+++ b/jasper_library/sw/jam/test/Makefile
@@ -49,7 +49,7 @@ core_info.o: core_info.bin
 		$< $@
 
 core_info.bin: core_info.tab
-	ruby ../util/cit2bin.rb $< > $@
+	python ../util/cit2csl.py -b $< > $@
 
 test:
 	@echo CC=$(CC)
@@ -57,6 +57,6 @@ test:
 	@echo OBJARCH=$(OBJARCH)
 
 clean:
-	rm csl_find_key_test csl_find_by_payload_test *.o core_info.bin
+	rm -f csl_find_key_test csl_find_by_payload_test *.o core_info.bin
 
 .PHONY: test clean

--- a/jasper_library/sw/jam/util/cit2csl.py
+++ b/jasper_library/sw/jam/util/cit2csl.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+# Convert a CASPER core_info.tab file to its binary CSL representation.
+# Outputs as either a binary file (default) or a memory file (use `-m`)
+# suitable for use 3ith Xilinx's `updatemem` utility.  For now the address in
+# the memory file is fixed at 0x1f000, but it would be easy to add a command
+# line option to allow the user to specify this if/when needed.
+#
+# core_info.tab files contain lines describing how CASPER yellow blocks are
+# mapped into the memory space of a CAPER FPGA design.  Historically, each line
+# is a core_info.tab file consists of four fields: device name, access mode,
+# offset, and length.  Modern core_info.tab files have a fifth field that
+# indicates the type of yellow block.  Clients can use this block type
+# information to determine how to interpret the contents of the block's memory
+# region.
+#
+# When converting a core_info.tab file to its binary CSL representation, the
+# device names are the strings of the CSL.  The payload of each CSL entry
+# consist of offset/mode, length, and type code.  Offset/mode is the four byte
+# offset within the FPGA memory space with the least significant bit being a
+# read-only flag.  Because FPGA devices are always at 4-byte aligned offsets,
+# the two least significant bits are implicitly 0 so these bits can be used to
+# carry additional information such as a read-only flag.  If the device is
+# read-only (i.e. unwritable) then the offset's LSb will be a '1'.  The length
+# field is also stored as four bytes.  The type code field is stored as a
+# single byte.
+#
+# The offset and length fields are stored in network byte order (big endian).
+
+import re
+import sys
+import struct
+import fileinput
+
+import argparse
+
+parser = argparse.ArgumentParser(description='Convert core_info.tab to CSL form.')
+parser.add_argument('-a', '--address', action='store',
+                    default=0x1f000, type=lambda x: int(x,0),
+                    help='Starting address for memory file')
+parser.add_argument('-b', '--bin', action='store_true',
+                    help='Output binary file rather than memory file')
+parser.add_argument('cit_file', nargs='?', default=None,
+                    help='A core_info.tab file')
+args = parser.parse_args()
+#print args; sys.exit()
+
+# Munge sys.argv so fileutil will be happy
+sys.argv = [sys.argv[0]]
+if args.cit_file:
+    sys.argv.append(args.cit_file)
+#print sys.argv; sys.exit()
+
+
+
+# Read and parse lines
+# Lines have 4 or 5 fields: dev mode offset length [typecode]
+lines = []
+for line in fileinput.input():
+    words = line.split()
+    dev = words[0]
+    mode = words[1]
+    offset = int(words[2], 16)
+    if mode == '1':
+        offset |= 1
+    length = int(words[3], 16)
+    if len(words) < 5:
+        # Missing type defaults to 0 (register)
+        typecode = 0
+    else:
+        typecode = int(words[4], 16)
+  
+    lines.append([dev, [offset, length, typecode]])
+
+# Sort lines
+lines.sort()
+
+payload_length = 9
+csl = b''
+prev = ''
+
+for (dev, entry) in lines:
+    reuse = min(len(prev), len(dev))
+    for i in range(reuse):
+        if prev[i] != dev[i]:
+            reuse = i
+            break
+
+    tail = dev[reuse:]
+    if len(csl) == 0:
+        reuse = payload_length
+
+    #print reuse, len(tail), tail, entry, dev
+    csl += struct.pack('>BB%dsIIB' % len(tail), reuse, len(tail), tail, *entry)
+
+    prev = dev
+
+# Append list terminator
+csl += b'\0\0'
+
+# Prepend length
+csl = struct.pack('>H', len(csl)) + csl
+
+if args.bin:
+    # Output CSL as binary
+    sys.stdout.write(csl)
+else:
+    # Output CSL as memory file
+    print '@%08X' % args.address
+    # Pad csl with 3 nul bytes (is this really necessary?)
+    csl += '\0\0\0'
+    # Split csl into lines of 1 to 32 bytes
+    lines = re.findall('.{1,32}', csl, re.MULTILINE|re.DOTALL)
+    for line in lines:
+        #sys.stderr.writelines(len(line))
+        sys.stdout.write('   ')
+        for byte in line:
+            sys.stdout.write(' %02X' % ord(byte))
+        sys.stdout.write('\n')

--- a/jasper_library/toolflow.py
+++ b/jasper_library/toolflow.py
@@ -457,13 +457,14 @@ class Toolflow(object):
         self.logger.debug('Opening %s' % basefile)
         with open(newfile, 'w') as fh:
             fh.write(s)
-        # generate the binary and xilinx-style .mem versions of this table, using some Ruby(!) scripts.
-        ret = os.system('ruby %s/jasper_library/cit2bin.rb %s > %s.bin' % (os.getenv('MLIB_DEVEL_PATH'), newfile, newfile))
+        # generate the binary and xilinx-style .mem versions of this table,
+        # using Python script [TODO convert to a callable function?].
+        ret = os.system('python %s/jasper_library/cit2csl.py -b %s > %s.bin' % (os.getenv('MLIB_DEVEL_PATH'), newfile, newfile))
         if ret != 0:
             errmsg = 'Failed to generate binary file {}.bin, error code {}.'.format(newfile,ret)
             self.logger.error(errmsg)
             raise Exception(errmsg)
-        ret = os.system('ruby %s/jasper_library/cit2mem.rb %s > %s.mem' % (os.getenv('MLIB_DEVEL_PATH'), newfile, newfile))
+        ret = os.system('python %s/jasper_library/cit2csl.py %s > %s.mem' % (os.getenv('MLIB_DEVEL_PATH'), newfile, newfile))
         if ret != 0:
             errmsg = 'Failed to generate xilinx-style file {}.mem, error code {}.'.format(newfile,ret)
             self.logger.error(msg)


### PR DESCRIPTION
As much as I hate to re-write working scripts, especially in a different
and less favored (by me) language, these scripts were not special enough
to justify a Ruby dependency for the JASPER toolflow.