### PR TITLE
Make same_state function more robust

### DIFF
--- a/casper_library/same_state.m
+++ b/casper_library/same_state.m
@@ -87,7 +87,8 @@ end % name/value pair loop
 
 % Determine whether the state has changed
 try
-    match = getfield(get_param(blk, 'UserData'), 'state') == hashcell(varargin);
+    state = getfield(get_param(blk, 'UserData'), 'state');
+    match = ~isempty(state) && (state == hashcell(varargin));
 catch
     match = 0;
 end


### PR DESCRIPTION
In the unlikely event that a block's `UserData` param has an empty
`state` field, ensure that `same_state` still returns a boolean
(specifically, a false value) rather than an empty array which can't be
used with || or &&.