### PR TITLE
Added How To for Matlab R2018a and Vivado 2018.2

### DIFF
--- a/docs/src/How-to-install-Matlab.md
+++ b/docs/src/How-to-install-Matlab.md
@@ -66,4 +66,35 @@ cd /opt/Matlab/R2016b/bin/
 NB: Make sure the file is executable and that the nautilius documentation navigator is set to run the script.
 
 20. Run the script and the Matlab IDE will launch. You can now select the required Matlab m files (*.m) and continue.
-21. In order to run Matlab with the Casper tools please look at the CASPER wiki page: https://casper.berkeley.edu/wiki/MSSGE_Setup_with_Xilinx_14.x_and_Matlab_2012b​ . NB: This may need to be updated when using R2016b (TBD).
+21. In order to run Matlab with the Casper tools please look at the CASPER read the docs page: https://casper-toolflow.readthedocs.io/en/latest/jasper_documentation.html.
+## How To Install R2018a
+
+1. OS Required/suggested: Ubuntu 14.04 LTS/Ubuntu 16.04 LTS.
+2. Ubuntu 16.04. Using Nautilius, click on “R2018a_glnxa64_dvd1.iso” and extract to “Installs/Matlab2018a”.
+3. Ubuntu 16.04. Open a terminal < ctrl + alt + T> and type `cd ~/Installs` and then type `chmod +w Matlab2018a/ -R`. This will give all the files in the Matlab2018a folder write access.
+4. Ubuntu 16.04. Using Nautilius, click on “R2018a_glnxa64_dvd2.iso” and extract to “Installs/Matlab2018a”.
+5. Open a terminal <ctrl + alt + T> and type `cd ​ ~/Installs/Matlab2018a/`,then `sudo ./install` and enter.
+6. The MathWorks Installer GUI should pop up. Select “Use a File Installation Key” and select “Next”.
+7. You will be requested to sign the “License Agreement” page. Click “Yes” and then click “Next”.
+8. You will be requested to fill in the file installation key for your license. The Matlab Administrator should of provided a license and file installation key. If not, make sure you get one from him. Type in the file installation key and press “Next”. I choose to install my license file under “~/Matlab”.
+9. You will then need to specify the installation folder. I choose “/opt/Matlab/R2018a”. Press “Select” and then “Next”.
+10. You will then see a “Product Selection” window. Make sure that all products are ticked and select “Next”.
+11. You must then decide where you want the symbolic links to your Matlab scripts to be stored. I chose the default location “/usr/local/bin”.
+12. You will then be required to confirm your installation settings. If happy then press “Install” else press “Back” and then return to this step when happy.
+13. You will be informed that your installation may require additional configuration skips. This can be ignored. Click “Next”.
+14. You will be informed that the installation is complete. Make sure Activate Matlab is ticked and click “Next”.
+15. It is now time to Activate MathWorks Software. A “MathWorks Software Activation” window will pop up. Click on the “Activate manually without the internet” and press “Next”.
+16. Click on the “Enter the full path to your license file, including the file name:” and browse to the license file (*.lic) and click “Select”. Then press “Next”. If all goes well then you will receive a message that says “Activation is complete.”. Click “Finish”.
+17. Open another terminal and navigate to the “opt” folder and remember to change user and group to your username with the following command: `​sudo chown <username>:<username> Matlab -R`
+18. Terminal: Navigate to the “home” folder and remember to change user and group to your username with the following command: `sudo chown <username>:<username> .matlab -R`
+19. It will be a good idea to create an Matlab R2016b startup script file on your Desktop with the following lines:
+```bash
+#!/bin/bash
+cd /opt/Matlab/R2018a/bin/
+./matlab
+```
+NB: Make sure the file is executable and that the nautilius documentation navigator is set to run the script.
+
+20. Run the script and the Matlab IDE will launch. You can now select the required Matlab m files (*.m) and continue.
+21. Install the R2018a update pack: "r2018a-update-6.tar.gz" by unpacking the tar.gz file and following the install instructions "r2018a-updates-install-instructions.pdf" for linux.
+22. In order to run Matlab with the Casper tools please look at the CASPER read the docs page: https://casper-toolflow.readthedocs.io/en/latest/jasper_documentation.html.

--- a/docs/src/How-to-install-Xilinx-Vivado.md
+++ b/docs/src/How-to-install-Xilinx-Vivado.md
@@ -1,5 +1,9 @@
 # How to install Xilinx Vivado
 
+This section explains How To install Vivado 2016.2, 2016.4 and 2018.2.
+
+## How to Install 2016.x
+
 1. OS Required/suggested: Ubuntu 14.04 LTS, Ubuntu 16.04 LTS (with tweaks) and Red Hat 6.6 (Santiago). There was an issue using Ubuntu 12.04 LTS, which caused the DocNav utility to crash. *Note: 2018.1 works with Ubuntu 16.04.3 LTS*
 2. Click/double click on the ``Xilinx_Vivado_SDK_2016.2_0605_1.tar.gz`` file in the Ubuntu Nautilius document navigator and choose a folder to extract the files to. I use “home/Installs`` in this document. If you use something different then remember to replace “Installs” with your directory name.
 3. Ubuntu 14.04. Open a terminal < ctrl + alt + T>. Change directory to
@@ -23,6 +27,52 @@ is highly recommended, as the documentation is part of the Ultrafast design meth
     ```bash
     #!/bin/bash
     cd /opt/Xilinx/Vivado/2016.2/bin/
+    ./vivado
+    ```
+    NB: Make sure the file is executable and that the nautilius documentation
+    navigator is set to run the script.
+19. Run the script and the Vivado IDE will launch. You can now select the required Xilinx Vivado project file (*.xpr) and continue.
+20. It is now time to install the license for Vivado. Create a ``Xilinx`` folder in your home directory using the nautilius documentation navigator: ``home/<user name>/Xilinx`` and copy the vivado license file provided by your administrator to this location.
+21. Load the license using the Vivado License Manager”. If not already open click on “Help” -> “Manage License...”. Click “Load License” and then click on “Copy License...”. Navigate to the license file (*.lic) in the ``home/<user name>/Xilinx`` folder. Press “Open” and when the license installation was successful then press “OK”.
+22. To confirm that the license file was successful, click on “View License Status” and make sure a list of Tools/IP is read back and that the license is still valid. Once this is done then close the “Vivado License Manager” by clicking on the red cross at the top left of the window. You will be prompted if you want to close the “Vivado License Manager”. Click “Yes”.
+
+## Optional: Install USB Drivers for JTAG
+
+The most reliable way to install the JTAG cable drivers is to use the drivers provided with ISE.
+
+A folder containing all the files required has been uploaded in the same folder as this document: [linux_jtag_cable_drivers.tar.gz](https://drive.google.com/file/d/0Byu0Sq2IEDuJdVFMMkNLN2pxYnc/view?usp=sharing). This also includes a useful installation script that prepares the files and places them in the correct directories.
+
+Instructions:
+* Extract the contents of the file linux_jtag_cable_drivers.tar.gz 
+* Run: ``sudo ./install.sh`` (NB!: Must run as sudo)
+
+It may be a good idea to power your PC/lap top down and then up again as the USB drivers may not take affect until this happens. In my case, I plugged a stick drive into the USB and then ejected that and connected the Xilinx Platform Cable USB module. Once this was done then the status LED illuminated and I was able to configure the FPGA via JTAG.
+
+## How to Install 2018.x
+
+1. OS Required/suggested: Ubuntu 14.04 LTS, Ubuntu 16.04 LTS (with tweaks). There was an issue using Ubuntu 12.04 LTS, which caused the DocNav utility to crash. *Note: 2018.1 works with Ubuntu 16.04.3 LTS*
+2. Click/double click on the ``Xilinx_Vivado_SDK_2018.2_0614_1954.tar.gz`` file in the Ubuntu Nautilius document navigator and choose a folder to extract the files to. I use “home/Installs`` in this document. If you use something different then remember to replace “Installs” with your directory name.
+3. Ubuntu 16.04. Open a terminal < ctrl + alt + T>. Change directory to
+the following folder: ``​cd Installs/Xilinx_Vivado_SDK_2018.2_0614_1954``
+4. Terminal: Type ``sudo ./xsetup`` and press enter. This application needs to be installed with root privileges otherwise the installation will not install properly. You will be prompted for the sudo password. Enter this and press enter.
+5. The Vivado Installer GUI will pop up. The GUI might explain that there is a new version available, but ignore that and press “Continue” and then “Next” to commence with the installation process.
+6. Read the terms and conditions page and when happy tick “I agree” for all three tick boxes. Then click “Next”.
+7. Select the “Vivado HL_System Edition” radio button and select “Next”.
+8. You will then be required to select which tools you want to install with the Vivado Design Edition. I selected “Software Development Kit”, “Ultrascale+” and “Zynq UltraScale + MPSoC”. The rest of the boxes were ticked (except Cable Drivers),so I have decided to install the complete set of tools available. Make sure that “DocNav” is ticked if you want access to the documentation that Xilinx has provided. This
+is highly recommended, as the documentation is part of the Ultrafast design methodology. Press “Next”.
+9. Select where you want to install the Vivado tool set. I am using the default ``opt/Xilinx`` folder. I have also ticked the “Create program group entries” and “create desktop shortcuts” buttons. This is not necessary though. Press “Next”.
+10. A window will pop up offering to create the ``opt/Xilinx`` directory if it does not exist. Select “Yes”.
+11. A window with the “Installation Summary” will be displayed showing what tools will be installed and where they will be stored on your drive. If you are happy press “Install”, otherwise press “Back” and edit your previous settings.
+12. Wait until the Xilinx Software Install window states that the “Installation completed successfully” and select “OK”.
+13. Open another terminal and navigate to the “opt” folder and remember to change user and group to your username with the following command: ``​sudo chown <username>:<username> Xilinx -R``
+14. Terminal: Navigate to the ``home`` folder and remember to change user and group to your username with the following command: ``​sudo chown <username>:<username> .Xilinx -R``
+15. If DocNav does not work, then try follow the steps highlighted in the text file: [set_up_vivado_2015.1_on_ubuntu_14.04](https://drive.google.com/file/d/0B2dCFqGD5y-8amdKbWZBM18yTEE/view?usp=sharing) (Doc Nav section only). Install the i386 architecture and then install the missing libraries. All the commands are highlighted in the attached file.
+16. DocNav may open, but it is possible you won’t be able to read the documentation until you have made the following link - first try and read the documentation via DocNav though. Using the terminal type in ``​cd /opt/Xilinx/Vivado/2016.2/ids_lite/ISE/lib/lin64`` and press enter.
+17. If you still can't access the documentation via DocNav: Using the terminal, type in ``​mv libstdc++.so.6 libstdc++.so.6bu`` and press enter. Now type in ``​ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./libstdc++.so.6`` and pressenter. The ``libstdc++.so.6`` file will now be properly linked and DocNav should work.
+18. It will be a good idea to create a vivado startup script file on your Desktop with the following lines:
+    ```bash
+    #!/bin/bash
+    cd /opt/Xilinx/Vivado/2018.2/bin/
     ./vivado
     ```
     NB: Make sure the file is executable and that the nautilius documentation


### PR DESCRIPTION
I have added a how to procedure for Matlab R2018a and Vivado 2018.2 to cover the gaps in the install procedures.