### PR TITLE
Implement some windowing functions and sinc with python

### DIFF
--- a/casper_library/pfb_coeff_gen_init.m
+++ b/casper_library/pfb_coeff_gen_init.m
@@ -63,8 +63,7 @@ debug_mode      = get_var('debug_mode', 'defaults', defaults, varargin{:});
 try
 	window('hamming',1024);
 catch
-	disp('pfb_coeff_gen_init:Signal Processing Library absent or not working correctly');
-	error('pfb_coeff_gen_init:Signal Processing Library absent or not working correctly');
+	warning('pfb_coeff_gen_init:Signal Processing Library absent or not working correctly');
 end
 %alltaps = TotalTaps*2^PFBSize;
 %windowval = transpose(window(WindowType, alltaps));

--- a/casper_library/python/window.py
+++ b/casper_library/python/window.py
@@ -1,0 +1,70 @@
+from math import sin, cos, pi
+
+# These window functions duplicated from numpy, because
+# importing numpy here breaks MATLAB ?!?
+
+def hanning(M):
+  if M < 1:
+    return []
+  if M == 1:
+    return [1.0]
+  nlist = range(0, M)
+  return [(0.5 - 0.5*cos(2.0*pi*n/(M-1))) for n in nlist]
+
+def blackman(M):
+  if M < 1:
+    return []
+  if M == 1:
+    return [1.0]
+  nlist = range(0, M)
+  return [(0.42 - 0.5*cos(2.0*pi*n/(M-1)) + 0.08*cos(4.0*pi*n/(M-1))) for n in nlist]
+
+def hamming(M):
+  if M < 1:
+    return []
+  if M == 1:
+    return [1.0]
+  nlist = range(0, M)
+  return [(0.54 - 0.46*cos(2.0*pi*n/(M-1))) for n in nlist]
+
+def window(wintype, N):
+  """
+  Try to replicate MATLAB's `window` function.
+  Inputs:
+    wintype (string) : window type, eg. "hann", "hamming", etc
+    N (int)          : Number of window points requested
+  This function will try to call numpy.`wintype`(N) to generate the
+  desired window.
+  """
+  # Remap names where we know MATLAB and numpy differ
+  # map is {MATLAB name : numpy name}
+  remap = {
+    "hann" : "hanning",
+  }
+  wintype = remap.get(wintype, wintype)
+  try:
+    winmethod = globals()[wintype]
+  except KeyError:
+    raise RuntimeError("Couldn't find window method '%s'" % wintype)
+    return
+  #try:
+  #  winmethod = getattr(numpy, wintype)
+  #except AttributeError:
+  #  print("Couldn't find window method numpy.%s" % wintype)
+  #  return
+  if callable(winmethod):
+    return winmethod(N)
+  else:
+    raise RuntimeError("Attribute numpy.%s is not callable" % wintype)
+    return
+
+def sinc(xlist):
+  if not isinstance(xlist, list):
+      return sinc([xlist])[0]
+  rv = []
+  for x in xlist:
+    try:
+      rv += [sin(pi*x) / (pi*x)]
+    except ZeroDivisionError:
+      rv += [1.0]
+  return rv

--- a/startup.m
+++ b/startup.m
@@ -42,5 +42,8 @@ if ~isempty(casper_startup_dir)
   end
 end
 
+% Add the local python directory to MATLAB's python environment
+insert(py.sys.path, int32(0), [getenv('MLIB_DEVEL_PATH'), '/casper_library/python'])
+
 clear casper_startup_dir;
 clear jasper_backend;


### PR DESCRIPTION
This avoids the need for the DSP toolbox when generating PFBs.

I followed the process in https://uk.mathworks.com/help/matlab/matlab_external/call-user-defined-custom-module.html
to implement these functions in user python.

Note that it would be easier/better to just use the numpy versions of the various
windows it supports. But this crashes MATLAB as per
https://uk.mathworks.com/matlabcentral/answers/503505-why-matlab-crashes-when-i-try-to-use-a-numpy-python-package-2019a

So for now, only hamming / hann / blackman are implemented