### PR TITLE
Give sys_block scratchpad a default value

### DIFF
--- a/jasper_library/yellow_blocks/sys_block.py
+++ b/jasper_library/yellow_blocks/sys_block.py
@@ -6,7 +6,8 @@ from .yellow_block_typecodes import *
 class sys_block(YellowBlock):
     def initialize(self):
         self.typecode = TYPECODE_SYSBLOCK
-        self.add_source('sys_block')             
+        self.add_source('sys_block')
+        if not hasattr(self, 'scratchpad'): self.scratchpad = 0
         # the internal memory_map
         self.memory_map = [
             Register('sys_board_id',   mode='r',  offset=0, default_val=self.board_id),


### PR DESCRIPTION
Commit 71aeffb introduced a required default scratchpad value to the
sys_block YellowBlock, causing all instantiations of it which don't
provide one to break.
This commit simply gives gives a default value of zero if no other
value has been specified at construction.