### PR TITLE
Updates to startsg.local.example

### DIFF
--- a/startsg.local.example
+++ b/startsg.local.example
@@ -1,8 +1,10 @@
-export XILINX_PATH=/opt/Vivado/2019.1
+# export XILINX_PATH=/opt/Xilinx/Vivado/2016.2
+# export XILINX_PATH=/media/amish/DATAPART1/opt/Vivado/2019.1
+export XILINX_PATH=/opt/Xilinx/Vivado/2019.1
 export MATLAB_PATH=/usr/local/MATLAB/R2018a
 export PLATFORM=lin64
 export JASPER_BACKEND=vivado
 export LD_PRELOAD=${LD_PRELOAD}:"/usr/lib/x86_64-linux-gnu/libexpat.so"
 
-# Activate a python3 virtual-environment on load
-export CASPER_PYTHON_VENV_ON_START=/path/to/your/casper-python3-venv
+# python3
+export CASPER_PYTHON_VENV_ON_START=/home/amish/Documents/work/_casper/casper_tools

--- a/startsg.local.example
+++ b/startsg.local.example
@@ -1,10 +1,8 @@
-# export XILINX_PATH=/opt/Xilinx/Vivado/2016.2
-# export XILINX_PATH=/media/amish/DATAPART1/opt/Vivado/2019.1
-export XILINX_PATH=/opt/Xilinx/Vivado/2019.1
+export XILINX_PATH=/opt/Vivado/2019.1
 export MATLAB_PATH=/usr/local/MATLAB/R2018a
 export PLATFORM=lin64
 export JASPER_BACKEND=vivado
 export LD_PRELOAD=${LD_PRELOAD}:"/usr/lib/x86_64-linux-gnu/libexpat.so"
 
-# python3
-export CASPER_PYTHON_VENV_ON_START=/home/amish/Documents/work/_casper/casper_tools
+# Activate a python3 virtual-environment on load
+export CASPER_PYTHON_VENV_ON_START=/path/to/your/casper-python3-venv

--- a/startsg.local.example
+++ b/startsg.local.example
@@ -1,10 +1,8 @@
-# export XILINX_PATH=/opt/Xilinx/Vivado/2016.2
-# export XILINX_PATH=/media/amish/DATAPART1/opt/Vivado/2019.1
 export XILINX_PATH=/opt/Xilinx/Vivado/2019.1
 export MATLAB_PATH=/usr/local/MATLAB/R2018a
 export PLATFORM=lin64
 export JASPER_BACKEND=vivado
 export LD_PRELOAD=${LD_PRELOAD}:"/usr/lib/x86_64-linux-gnu/libexpat.so"
 
-# python3
-export CASPER_PYTHON_VENV_ON_START=/home/amish/Documents/work/_casper/casper_tools
+# Activate a python3 virtual-environment on load
+export CASPER_PYTHON_VENV_ON_START=/path/to/your/casper-python3-venv


### PR DESCRIPTION
Fixing three things:
1. My original (erroneous) commit of startsg.local.example.
2. Updating the example file to resemble that in tutorials_devel.
3. Fixing my error in specifying the `XILINX_PATH` - initially committed `/opt/Vivado/2019.1` where it needs to be `/opt/**Xilinx**/Vivado/2019.1`.

Apologies!