### PR TITLE
Fixed toolflow files to build in Ubuntu 16.04LTS

### DIFF
--- a/jasper_library/castro.py
+++ b/jasper_library/castro.py
@@ -29,7 +29,7 @@ class Castro(object):
         loads this class object from a yaml file and assert that it is of type Castro
         '''
         with open(filename, 'r') as fh:
-            c = yaml.load(fh)
+            c = yaml.load(fh, Loader=yaml.Loader)
             assert isinstance(c, Castro)
             return c
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<1.9
 colorlog
 pyaml
 odict


### PR DESCRIPTION
The requirements.txt file has been updated with the "numpy<1.19". Version 1.18.5 was the last to support Python 3.5, which we are using. The newer version causes conflicts. Also castro.py causes constructor error due to python pyyaml updates. This was working with pyyaml version 3.13, but not version 5.1 and above. It suggested that I add "Loader=yaml.Loader" to the yaml.load() function and it no longer breaks - checkout https://github.com/yaml/pyyaml/issues/266. The toolfow is now able to build in Ubuntu 16.04LTS again - tested using the Red Pitaya test slx file. I also tested my old working virtual environment with the old python packages and that builds too, so is backwards compatible.