### PR TITLE
Installed fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-numpy<1.9
+numpy<1.19
 colorlog
+PyYAML<=5.4.1
 pyaml
 odict
 #xml2vhdl requirements
 lxml
--e git+http://github.com/casper-astro/xml2vhdl#egg=xml2vhdl_ox-0.2.2-py3.5.egg&subdirectory=scripts/python/xml2vhdl-ox
+-e git+https://github.com/casper-astro/xml2vhdl#egg=xml2vhdl_ox&subdirectory=scripts/python/xml2vhdl-ox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy<1.19
 colorlog
-PyYAML<=5.4.1
 pyaml
 odict
 #xml2vhdl requirements


### PR DESCRIPTION
changed numpy version for compatibility  i.e https://www.mail-archive.com/casper@lists.berkeley.edu/msg08532.html
changed to https for github download
Tested in a fresh python 3 environment and installs without error. 
Tested with vivado 2019.1.1 and Matlab R2018a, compiled into tutorial for red pitaya board without error. 
