### PR TITLE
Updating the gpio driving the au50 cattrip pin

### DIFF
--- a/jasper_library/hdl_sources/au50_infr/au50_bd.tcl
+++ b/jasper_library/hdl_sources/au50_infr/au50_bd.tcl
@@ -252,7 +252,7 @@ proc create_root_design { parentCell } {
   # Create instance: axi_gpio_0, and set properties
   set axi_gpio_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_gpio:2.0 axi_gpio_0 ]
   set_property -dict [ list \
-   CONFIG.C_DOUT_DEFAULT {0x00000001} \
+   CONFIG.C_DOUT_DEFAULT {0x00000000} \
    CONFIG.GPIO_BOARD_INTERFACE {hbm_cattrip} \
    CONFIG.USE_BOARD_FLOW {true} \
  ] $axi_gpio_0


### PR DESCRIPTION
This should have been driving the pin low and not high.

Still need to investigate why the SARAO au50s work with this set to 1.