### PR TITLE
Fixed VHDL update for Vivado 2021.1

### DIFF
--- a/jasper_library/hdl_sources/skarab_adc4x3g_14_byp/ADC32RF45_11G2_RX.vhd
+++ b/jasper_library/hdl_sources/skarab_adc4x3g_14_byp/ADC32RF45_11G2_RX.vhd
@@ -1132,7 +1132,7 @@ begin
 					-- Check for k28p3 frequency errors
 					for i in 0 to 3 loop
 						if chbnd_detk28p3_z1(i) = '1' then
-							chbnd_plsfreq_cnt(i) <= to_unsigned(0, 8);
+							chbnd_plsfreq_cnt(i) <= (others=>'0'),(others=>'0'),(others=>'0'),(others=>'0');
 						else
 							if chbnd_plsfreq_cnt(i) <= 31 then -- count up to 32
 								chbnd_plsfreq_cnt(i) <= chbnd_plsfreq_cnt(i) + 1;


### PR DESCRIPTION
I initialise the array to zero using new VHDL standard for arrays - line 1135 (others=>'0'),(others=>'0'),(others=>'0'),(others=>'0')