### PR TITLE
rfsoc fixes

### DIFF
--- a/jasper_library/toolflow.py
+++ b/jasper_library/toolflow.py
@@ -1549,6 +1549,10 @@ class VitisBackend(ToolflowBackend):
         xsct_tcl = os.path.join(self.compile_dir, 'xsct_gogogo.tcl')
         helpers.write_file(xsct_tcl, xc)
 
+        # TODO removing `XILINX_PATH` here is a hack for now to work updating Vitis 2020.2 to Vitis 2021.1
+        # for newer versions of the tools `XILINX_PATH` is an env var that Xilinx uses for their Vitis tool
+        # and our library env var clobbers it causing xsct to fail when starting
+        del os.environ['XILINX_PATH']
         rv = os.system('xsct {:s}'.format(xsct_tcl))
         if rv:
             raise Exception('xsct (Vitis) failed!')

--- a/jasper_library/yellow_blocks/rfdc.py
+++ b/jasper_library/yellow_blocks/rfdc.py
@@ -590,7 +590,8 @@ class rfdc(YellowBlock):
 
     # place the rfdc
     rfdc_bd_name = 'usp_rf_data_converter_0'#rfdc'
-    tcl_cmds['pre_synth'] += ['create_bd_cell -type ip -vlnv xilinx.com:ip:usp_rf_data_converter:2.4 {:s}'.format(rfdc_bd_name)]
+    # TODO better handle version information, the version string was manually increasesd when testing for > Vivado 2020.2
+    tcl_cmds['pre_synth'] += ['create_bd_cell -type ip -vlnv xilinx.com:ip:usp_rf_data_converter:2.5 {:s}'.format(rfdc_bd_name)]
 
     # get a reference to the rfdc in the block design, currently assume that only one rfdc is in the design (decent assumption)
     tcl_cmds['pre_synth'] += ['set rfdc [get_bd_cells -filter { NAME =~ *usp_rf_data_converter*}]']

--- a/startup.m
+++ b/startup.m
@@ -7,7 +7,7 @@ warning off Simulink:Commands:LoadMdlParameterizedLink
 jasper_backend = getenv('JASPER_BACKEND');
 
 %if vivado is to be used
-if strcmp(jasper_backend, 'vivado') || isempty(jasper_backend)
+if strcmp(jasper_backend, 'vivado') || strcmp(jasper_backend, 'vitis') || isempty(jasper_backend)
   disp('Starting Model Composer')
   addpath([getenv('MLIB_DEVEL_PATH'), '/casper_library']);
   addpath([getenv('MLIB_DEVEL_PATH'), '/xps_library']);
@@ -31,7 +31,7 @@ elseif strcmp(jasper_backend, 'ise')
   xlAddSysgen([getenv('XILINX_PATH'), '/ISE'])
   sysgen_startup
 else
-  fprintf('Unknown JASPER_BACKEND ''%s''\n', jasper_library);
+  fprintf('Unknown JASPER_BACKEND ''%s''\n', jasper_backend);
   % Hopefully helpful in this case
   addpath([getenv('MLIB_DEVEL_PATH'), '/casper_library']);
   addpath([getenv('MLIB_DEVEL_PATH'), '/xps_library']);

--- a/xps_library/rfdc_mask.m
+++ b/xps_library/rfdc_mask.m
@@ -46,6 +46,9 @@ function [] = rfdc_mask(gcb,force)
     return
   end
 
+  % Disable link
+  set_param(blk, 'LinkStatus', 'inactive');
+
   msk = Simulink.Mask.get(gcb);
 
   [gen, tile_arch, fs_max, fs_min] = get_rfsoc_properties(gcb);


### PR DESCRIPTION
- recover startup of vitis from startsg

- temporary fix to remove jasper `XILINX_PATH` from env before launching xsct
for device tree generation. Later versions of the tool rely on `XILINX_PATH`
that is setup by xilinx and we clobber it on startup

- temporary fix to bump rfdc version