### PR TITLE
Minor edits to previous merge

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -166,7 +166,7 @@ Ubuntu 24.04 was released on April 25, 2024. It is not supported by Matlab R2022
 
      .. code-block:: bash
 
-          sudo add-apt-repository -S 'deb https://ppa.launchpadcontent.net/rock-core/qt4/ubuntu/ focal main`
+          sudo add-apt-repository -S 'deb https://ppa.launchpadcontent.net/rock-core/qt4/ubuntu/ focal main'
 
 
   After this, you can then install *libqt4core4* via :code:`sudo apt-get install libqtcore4`.

--- a/docs/src/How-to-install-Matlab.rst
+++ b/docs/src/How-to-install-Matlab.rst
@@ -11,6 +11,7 @@ This section explains how to install MATLAB.
 #. Required OS: Ubuntu 20.04 LTS.
 #. Download the MATLAB installer `here <https://www.mathworks.com/downloads/>`_. Select the ``2021a`` install, and the ``Download for Linux`` option.
 #. Run the following in the terminal:
+
    .. code-block:: bash
 
        cd /path/to/matlab/download/matlab_R2021a_glnxa64.zip


### PR DESCRIPTION
Command in Ubuntu 24.04 instructions had a wrong character and code block in Matlab installation instructions was missing a space so it wasn't displaying properly.